### PR TITLE
Fix string equals if other is null and string constant pool

### DIFF
--- a/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/nodes/BytecodeNode.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/nodes/BytecodeNode.java
@@ -2136,11 +2136,9 @@ public final class BytecodeNode extends EspressoMethodNode implements BytecodeOS
         } else if (constant instanceof StringConstant) {
             assert opcode == LDC || opcode == LDC_W;
             StaticObject internedString = pool.resolvedStringAt(cpi);
-            Meta meta = getMeta();
-            StaticObject obj = meta.toGuestString(meta.toHostString(internedString));
-            SPouT.markObjectWithIFTaint(obj);
+            SPouT.markObjectWithIFTaint(internedString);
             //TODO: (annotate string and maybe clone?)
-            putObject(frame, top, obj);
+            putObject(frame, top, internedString);
         } else if (constant instanceof ClassConstant) {
             assert opcode == LDC || opcode == LDC_W;
             Klass klass = pool.resolvedKlassAt(getDeclaringKlass(), cpi);

--- a/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/spout/SPouT.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/spout/SPouT.java
@@ -1568,6 +1568,10 @@ public class SPouT {
 
     @CompilerDirectives.TruffleBoundary
     public static Object stringEquals(StaticObject self, StaticObject other, Meta meta) {
+        // other might be null
+        if(!other.isString()){
+            return false;
+        }
         String cSelf = meta.toHostString(self);
         String cOther = meta.toHostString(other);
         boolean areEqual = cSelf.equals(cOther);


### PR DESCRIPTION
The loop from internedString to host and back to guest crashes the constant handling in the constant pool. I think, it should be sufficient to just hand over the internedString to SPouT and add it to the pool. String equals has not gracefully handled comparison with null in all cases.

This PR is recommended as replacement to #2. I personally prefer the loop over the underlying VM wherever possible instead of faithfully modeling the string library behavior in the substitution methods.