### PR TITLE
Implement IntegerCache semantics compliant with JLS

### DIFF
--- a/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/substitutions/Target_java_lang_Character.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/substitutions/Target_java_lang_Character.java
@@ -39,6 +39,36 @@ public final class Target_java_lang_Character {
     }
 
     @Substitution(passAnnotations = true)
+    public static @JavaType(internalName = "Z") Object isAlphabetic(@JavaType(internalName = "I") Object codePoint, @Inject Meta meta){
+        return SPouT.characterIsAlphabetic(codePoint, meta);
+    }
+
+    @Substitution(passAnnotations = true)
+    public static @JavaType(internalName = "Z") Object isJavaIdentifierStart(@JavaType(internalName = "I") Object codePoint, @Inject Meta meta){
+        return SPouT.characterIsJavaIdentifierStart(codePoint, meta);
+    }
+
+    @Substitution(passAnnotations = true)
+    public static @JavaType(internalName = "Z") Object isJavaIdentifierPart(@JavaType(internalName = "I") Object codePoint, @Inject Meta meta){
+        return SPouT.characterIsJavaIdentifierPart(codePoint, meta);
+    }
+
+    @Substitution(passAnnotations = true)
+    public static @JavaType(internalName = "Z") Object isUnicodeIdentifierStart(@JavaType(internalName = "I") Object codePoint, @Inject Meta meta){
+        return SPouT.characterIsUnicodeIdentifierStart(codePoint, meta);
+    }
+
+    @Substitution(passAnnotations = true)
+    public static @JavaType(internalName = "Z") Object isUnicodeIdentifierPart(@JavaType(internalName = "I") Object codePoint, @Inject Meta meta){
+        return SPouT.characterIsUnicodeIdentifierPart(codePoint, meta);
+    }
+
+    @Substitution(passAnnotations = true)
+    public static @JavaType(internalName = "Z") Object isIdentifierIgnorable(@JavaType(internalName = "I") Object codePoint, @Inject Meta meta){
+        return SPouT.characterIsIdentiferIgnorable(codePoint, meta);
+    }
+
+    @Substitution(passAnnotations = true)
     public static @JavaType(Character.class) StaticObject valueOf(@JavaType(internalName = "C") Object cIn, @Inject Meta meta){
         return SPouT.characterValueOf(cIn, meta);
     }

--- a/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/substitutions/Target_java_lang_Integer.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/substitutions/Target_java_lang_Integer.java
@@ -2,6 +2,9 @@ package com.oracle.truffle.espresso.substitutions;
 
 import com.oracle.truffle.espresso.meta.Meta;
 import com.oracle.truffle.espresso.runtime.StaticObject;
+import tools.aqua.spout.AnnotatedVM;
+import tools.aqua.spout.AnnotatedValue;
+import tools.aqua.spout.Annotations;
 import tools.aqua.spout.SPouT;
 
 @EspressoSubstitutions
@@ -10,5 +13,14 @@ public final class Target_java_lang_Integer {
     @Substitution
     public static int parseInt(@JavaType(String.class) StaticObject s, @Inject Meta meta){
         return SPouT.parseInt(s, meta);
+    }
+
+    @Substitution(passAnnotations = true)
+    public static @JavaType(Integer.class) StaticObject valueOf(@JavaType(internalName = "I") Object i, @Inject Meta meta) {
+        StaticObject o = meta.java_lang_Integer.allocateInstance();
+        meta.java_lang_Integer_value.set(o, AnnotatedValue.value(i));
+        AnnotatedVM.setFieldAnnotation(o, meta.java_lang_Integer_value,
+                AnnotatedValue.svalue(i));
+        return o;
     }
 }

--- a/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/substitutions/Target_java_lang_Integer.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/substitutions/Target_java_lang_Integer.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.espresso.meta.Meta;
 import com.oracle.truffle.espresso.runtime.StaticObject;
 import tools.aqua.spout.AnnotatedVM;
 import tools.aqua.spout.AnnotatedValue;
-import tools.aqua.spout.Annotations;
 import tools.aqua.spout.SPouT;
 
 @EspressoSubstitutions
@@ -17,10 +16,6 @@ public final class Target_java_lang_Integer {
 
     @Substitution(passAnnotations = true)
     public static @JavaType(Integer.class) StaticObject valueOf(@JavaType(internalName = "I") Object i, @Inject Meta meta) {
-        StaticObject o = meta.java_lang_Integer.allocateInstance();
-        meta.java_lang_Integer_value.set(o, AnnotatedValue.value(i));
-        AnnotatedVM.setFieldAnnotation(o, meta.java_lang_Integer_value,
-                AnnotatedValue.svalue(i));
-        return o;
+        return SPouT.integer_valueOf_int(i, meta);
     }
 }

--- a/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/substitutions/Target_java_lang_Math.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/substitutions/Target_java_lang_Math.java
@@ -22,6 +22,7 @@
  */
 package com.oracle.truffle.espresso.substitutions;
 
+import com.oracle.truffle.espresso.classfile.constantpool.MethodTypeConstant;
 import com.oracle.truffle.espresso.meta.Meta;
 import tools.aqua.spout.SPouT;
 
@@ -129,24 +130,24 @@ public final class Target_java_lang_Math {
         return SPouT.mathRoundD(a, meta);
     }
 
-    @Substitution
-    public static int abs(int a) {
-        return Math.abs(a);
+    @Substitution(passAnnotations = true, methodName = "abs")
+    public static @JavaType(internalName = "I") Object absInt(@JavaType(internalName = "I") Object a) {
+        return SPouT.mathAbsInt(a);
     }
 
-    @Substitution
-    public static long abs(long a) {
-        return Math.abs(a);
+    @Substitution(passAnnotations = true, methodName = "abs")
+    public static @JavaType(internalName = "J") Object absLong(@JavaType(internalName = "J") Object a) {
+        return SPouT.mathAbsLong(a);
     }
 
-    @Substitution
-    public static float abs(float a) {
-        return Math.abs(a);
+    @Substitution(passAnnotations = true, methodName = "abs")
+    public static @JavaType(internalName = "F") Object absFloat(@JavaType(internalName = "F") Object a) {
+        return SPouT.mathAbsFloat(a);
     }
 
-    @Substitution
-    public static double abs(double a) {
-        return Math.abs(a);
+    @Substitution(passAnnotations = true, methodName = "abs")
+    public static @JavaType(internalName = "D") Object absDouble(@JavaType(internalName = "D") Object a) {
+        return SPouT.mathAbsDouble(a);
     }
 
     @Substitution

--- a/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/substitutions/Target_java_lang_String.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/substitutions/Target_java_lang_String.java
@@ -3,7 +3,6 @@ package com.oracle.truffle.espresso.substitutions;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.espresso.meta.Meta;
 import com.oracle.truffle.espresso.runtime.StaticObject;
-import tools.aqua.spout.AnnotatedValue;
 import tools.aqua.spout.SPouT;
 
 import java.util.Locale;
@@ -145,7 +144,7 @@ public final class Target_java_lang_String {
     @Substitution(methodName = "valueOf", passAnnotations = true)
     @CompilerDirectives.TruffleBoundary
     public static @JavaType(String.class) StaticObject valueOf_int(@JavaType(internalName = "I") Object v, @Inject Meta meta) {
-        return SPouT.valueOf_int(v, meta);
+        return SPouT.string_valueOf_int(v, meta);
     }
 
     @Substitution(methodName = "valueOf", passAnnotations = true)

--- a/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/concolic/ConcolicAnalysis.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/concolic/ConcolicAnalysis.java
@@ -45,7 +45,6 @@ import static tools.aqua.smt.OperatorComparator.F2D;
 import static tools.aqua.smt.OperatorComparator.I2L;
 import static tools.aqua.smt.OperatorComparator.IOR;
 import static tools.aqua.smt.OperatorComparator.IADD;
-import static tools.aqua.smt.OperatorComparator.IOR;
 import static tools.aqua.smt.OperatorComparator.ISHR;
 import static tools.aqua.smt.OperatorComparator.L2D;
 import static tools.aqua.smt.OperatorComparator.L2F;

--- a/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/concolic/ConcolicAnalysis.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/concolic/ConcolicAnalysis.java
@@ -822,7 +822,7 @@ public class ConcolicAnalysis implements Analysis<Expression> {
 
         // special case: cached Integer
         if (meta.java_lang_Integer.equals(c1.getKlass()) &&
-                meta.java_lang_Integer.equals(c1.getKlass())) {
+                meta.java_lang_Integer.equals(c2.getKlass())) {
 
             Expression e1 = c1 == null ? null : Annotations.annotation(
                     AnnotatedVM.getFieldAnnotation(c1, meta.java_lang_Integer_value), config.getConcolicIdx());
@@ -832,24 +832,21 @@ public class ConcolicAnalysis implements Analysis<Expression> {
             if (e1 != null || e2 != null) {
 
                 int int1 = meta.java_lang_Integer_value.getInt(c1);
-                int int2 = meta.java_lang_Integer_value.getInt(c1);
+                int int2 = meta.java_lang_Integer_value.getInt(c2);
 
                 e1 = e1 == null ? Expression.fromConstant(Types.INT, int1) : e1;
-                e2 = e2 == null ? Expression.fromConstant(Types.INT, int1) : e2;
+                e2 = e2 == null ? Expression.fromConstant(Types.INT, int2) : e2;
 
                 expr = new ComplexExpression(BAND,
                         new ComplexExpression(BVEQ, e1, e2),
-                        new ComplexExpression(BVLE, Expression.fromConstant(Types.INT, 127), e1),
-                        new ComplexExpression(BVLE, e1, Expression.fromConstant(Types.INT, 127)));
+                        new ComplexExpression(BVLE, Expression.fromConstant(Types.INT, -128), e1),
+                        new ComplexExpression(BVLE, e1, Expression.fromConstant(Types.INT, 127)),
+                        // remaining not strictly necessary?
+                        new ComplexExpression(BVLE, Expression.fromConstant(Types.INT, -128), e2),
+                        new ComplexExpression(BVLE, e2, Expression.fromConstant(Types.INT, 127)));
 
-                if (int1 == int2 && -128 <= int1 && int1 <= 127) {
-                    if (opcode == IF_ACMPNE) {
-                        expr = new ComplexExpression(BNEG, expr);
-                    }
-                } else {
-                    if (opcode == IF_ACMPEQ) {
-                        expr = new ComplexExpression(BNEG, expr);
-                    }
+                if (!(int1 == int2 && -128 <= int1 && int1 <= 127)) {
+                    expr = new ComplexExpression(BNEG, expr);
                 }
                 PathCondition pc = new PathCondition(expr, takeBranch ? FAILURE : SUCCESS, BINARY_SPLIT);
                 trace.addElement(pc);

--- a/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/concolic/ConcolicAnalysis.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/concolic/ConcolicAnalysis.java
@@ -43,8 +43,14 @@ import static tools.aqua.smt.OperatorComparator.*;
 import static tools.aqua.smt.OperatorComparator.D2F;
 import static tools.aqua.smt.OperatorComparator.F2D;
 import static tools.aqua.smt.OperatorComparator.I2L;
+import static tools.aqua.smt.OperatorComparator.IADD;
+import static tools.aqua.smt.OperatorComparator.IOR;
+import static tools.aqua.smt.OperatorComparator.ISHR;
 import static tools.aqua.smt.OperatorComparator.L2D;
 import static tools.aqua.smt.OperatorComparator.L2F;
+import static tools.aqua.smt.OperatorComparator.LADD;
+import static tools.aqua.smt.OperatorComparator.LOR;
+import static tools.aqua.smt.OperatorComparator.LSHR;
 import static tools.aqua.smt.Types.LONG;
 
 public class ConcolicAnalysis implements Analysis<Expression> {
@@ -152,12 +158,12 @@ public class ConcolicAnalysis implements Analysis<Expression> {
 
     @Override
     public Expression iadd(int c1, int c2, Expression a1, Expression a2) {
-        return binarySymbolicOp(OperatorComparator.IADD, Types.INT, c1, c2, a1, a2);
+        return binarySymbolicOp(IADD, Types.INT, c1, c2, a1, a2);
     }
 
     @Override
     public Expression ladd(long c1, long c2, Expression a1, Expression a2) {
-        return binarySymbolicOp(OperatorComparator.LADD, LONG, c1, c2, a1, a2);
+        return binarySymbolicOp(LADD, LONG, c1, c2, a1, a2);
     }
 
     @Override
@@ -195,7 +201,7 @@ public class ConcolicAnalysis implements Analysis<Expression> {
         Expression sym = null;
         if (s1 != null) {
             Constant symbIncr = Constant.fromConcreteValue(incr);
-            sym = new ComplexExpression(OperatorComparator.IADD, s1, symbIncr);
+            sym = new ComplexExpression(IADD, s1, symbIncr);
         }
         return sym;
     }
@@ -273,7 +279,7 @@ public class ConcolicAnalysis implements Analysis<Expression> {
                     convertCharToInt(a1) : Constant.fromConcreteValue(c1), INT_0x3F));
         }
         a2 = convertCharToInt(a2);
-        return binarySymbolicOp(OperatorComparator.LSHR, LONG, Types.INT, c2, c1, a2, a1);
+        return binarySymbolicOp(LSHR, LONG, Types.INT, c2, c1, a2, a1);
     }
 
 
@@ -294,7 +300,7 @@ public class ConcolicAnalysis implements Analysis<Expression> {
             a1 = new ComplexExpression(OperatorComparator.IAND, convertCharToInt(a1), INT_0x1F);
         }
         a2 = convertCharToInt(a2);
-        return binarySymbolicOp(OperatorComparator.ISHR, Types.INT, c2, c1, a2, a1);
+        return binarySymbolicOp(ISHR, Types.INT, c2, c1, a2, a1);
     }
 
     @Override
@@ -537,7 +543,7 @@ public class ConcolicAnalysis implements Analysis<Expression> {
 
     @Override
     public Expression ior(int c1, int c2, Expression a1, Expression a2) {
-        return binarySymbolicOp(OperatorComparator.IOR, Types.INT, c1, c2, a1, a2);
+        return binarySymbolicOp(IOR, Types.INT, c1, c2, a1, a2);
     }
 
     @Override
@@ -552,7 +558,7 @@ public class ConcolicAnalysis implements Analysis<Expression> {
 
     @Override
     public Expression lor(long c1, long c2, Expression a1, Expression a2) {
-        return binarySymbolicOp(OperatorComparator.LOR, LONG, c1, c2, a1, a2);
+        return binarySymbolicOp(LOR, LONG, c1, c2, a1, a2);
     }
 
     @Override
@@ -894,6 +900,30 @@ public class ConcolicAnalysis implements Analysis<Expression> {
     @Override
     public Expression mathArcTan(double c, Expression s) {
         return new ComplexExpression(MATHATAN, s);
+    }
+
+    @Override
+    public Expression mathAbs(int c, Expression s) {
+        ComplexExpression res = new ComplexExpression(ISHR, s, Constant.fromConcreteValue(31));
+        ComplexExpression addRes = new ComplexExpression(IADD, res, s);
+        return new ComplexExpression(IOR, res, addRes);
+    }
+
+    @Override
+    public Expression mathAbs(long c, Expression s) {
+        ComplexExpression res = new ComplexExpression(LSHR, s, Constant.fromConcreteValue(63));
+        ComplexExpression addRes = new ComplexExpression(LADD, res, s);
+        return new ComplexExpression(LOR, res, addRes);
+    }
+
+    @Override
+    public Expression mathAbs(float c, Expression s) {
+        return new ComplexExpression(FPABS, s);
+    }
+
+    @Override
+    public Expression mathAbs(double c, Expression s) {
+        return new ComplexExpression(FPABS, s);
     }
 
     //__________________________________________________________________

--- a/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/concolic/ConcolicAnalysis.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/concolic/ConcolicAnalysis.java
@@ -43,6 +43,7 @@ import static tools.aqua.smt.OperatorComparator.*;
 import static tools.aqua.smt.OperatorComparator.D2F;
 import static tools.aqua.smt.OperatorComparator.F2D;
 import static tools.aqua.smt.OperatorComparator.I2L;
+import static tools.aqua.smt.OperatorComparator.IOR;
 import static tools.aqua.smt.OperatorComparator.IADD;
 import static tools.aqua.smt.OperatorComparator.IOR;
 import static tools.aqua.smt.OperatorComparator.ISHR;
@@ -808,6 +809,54 @@ public class ConcolicAnalysis implements Analysis<Expression> {
 
         PathCondition pc = new PathCondition(expr, takeBranch ? FAILURE : SUCCESS, BINARY_SPLIT);
         trace.addElement(pc);
+    }
+
+    @Override
+    public void takeBranchRef2(VirtualFrame frame, BytecodeNode bcn, int bci, int opcode, boolean takeBranch, StaticObject c1, StaticObject c2, Expression a1, Expression a2) {
+        if ((a1 == null) && (a2 == null)) {
+            return;
+        }
+
+        Expression expr = null;
+        Meta meta = bcn.getMeta();
+
+        // special case: cached Integer
+        if (meta.java_lang_Integer.equals(c1.getKlass()) &&
+                meta.java_lang_Integer.equals(c1.getKlass())) {
+
+            Expression e1 = c1 == null ? null : Annotations.annotation(
+                    AnnotatedVM.getFieldAnnotation(c1, meta.java_lang_Integer_value), config.getConcolicIdx());
+            Expression e2 = c2 == null ? null : Annotations.annotation(
+                    AnnotatedVM.getFieldAnnotation(c2, meta.java_lang_Integer_value), config.getConcolicIdx());
+
+            if (e1 != null || e2 != null) {
+
+                int int1 = meta.java_lang_Integer_value.getInt(c1);
+                int int2 = meta.java_lang_Integer_value.getInt(c1);
+
+                e1 = e1 == null ? Expression.fromConstant(Types.INT, int1) : e1;
+                e2 = e2 == null ? Expression.fromConstant(Types.INT, int1) : e2;
+
+                expr = new ComplexExpression(BAND,
+                        new ComplexExpression(BVEQ, e1, e2),
+                        new ComplexExpression(BVLE, Expression.fromConstant(Types.INT, 127), e1),
+                        new ComplexExpression(BVLE, e1, Expression.fromConstant(Types.INT, 127)));
+
+                if (int1 == int2 && -128 <= int1 && int1 <= 127) {
+                    if (opcode == IF_ACMPNE) {
+                        expr = new ComplexExpression(BNEG, expr);
+                    }
+                } else {
+                    if (opcode == IF_ACMPEQ) {
+                        expr = new ComplexExpression(BNEG, expr);
+                    }
+                }
+                PathCondition pc = new PathCondition(expr, takeBranch ? FAILURE : SUCCESS, BINARY_SPLIT);
+                trace.addElement(pc);
+            }
+            // nothing to trace symbolically
+        }
+        // TODO: general object equality not handled currently
     }
 
     @Override

--- a/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/smt/OperatorComparator.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/smt/OperatorComparator.java
@@ -162,7 +162,8 @@ public enum OperatorComparator {
     MATHEXP,
     MATHSQRT,
     MATHARCSIN,
-    MATHARCCOS;
+    MATHARCCOS,
+    FPABS;
 
 
 
@@ -374,6 +375,9 @@ public enum OperatorComparator {
                 return "ARCCOS";
             case MATHARCSIN:
                 return "ARCSIN";
+            case FPABS:
+                return "fp.abs";
+
 
             default:
                 return super.toString();

--- a/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/spout/Analysis.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/spout/Analysis.java
@@ -317,6 +317,10 @@ public interface Analysis<T> {
     }
 
     // Math
+    default  T mathAbs(int c, T s){return  null;}
+    default  T mathAbs(long c, T s){return  null;}
+    default  T mathAbs(float c, T s){return  null;}
+    default  T mathAbs(double c, T s){return  null;}
     default  T mathSin(double c, T s){return  null;}
     default  T mathCos(double c, T s){return  null;}
     default  T mathSqrt(double c, T s){return  null;}

--- a/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/spout/MetaAnalysis.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/spout/MetaAnalysis.java
@@ -895,6 +895,26 @@ public class MetaAnalysis implements Analysis<Annotations> {
     }
 
     @Override
+    public Annotations mathAbs(int c, Annotations s) {
+        return execute(c, s, Analysis::mathAbs);
+    }
+
+    @Override
+    public Annotations mathAbs(long c, Annotations s) {
+        return lexecute(c, s, Analysis::mathAbs);
+    }
+
+    @Override
+    public Annotations mathAbs(float c, Annotations s) {
+        return fexecute(c, s, Analysis::mathAbs);
+    }
+
+    @Override
+    public Annotations mathAbs(double c, Annotations s) {
+        return dexecute(c, s, Analysis::mathAbs);
+    }
+
+    @Override
     public Annotations mathArcSin(double c, Annotations s) {
         if (s == null) return null;
         return dexecute(c, s, Analysis::mathArcSin);

--- a/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/spout/SPouT.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/spout/SPouT.java
@@ -1205,20 +1205,39 @@ public class SPouT {
         assert IF_ACMPEQ <= opcode && opcode <= IF_ACMPNE;
         boolean result;
         // @formatter:off
-        switch (opcode) {
-            case IF_ACMPEQ : result =  operand1 == operand2; break;
-            case IF_ACMPNE : result =  operand1 != operand2; break;
-            default        :
-                CompilerDirectives.transferToInterpreterAndInvalidate();
-                throw EspressoError.shouldNotReachHere("expecting IF_ACMPEQ,IF_ACMPNE");
-        }
-        // @formatter:on
+        if (!analyze) {
+            switch (opcode) {
+                case IF_ACMPEQ : result =  operand1 == operand2; break;
+                case IF_ACMPNE : result =  operand1 != operand2; break;
+                default        :
+                    CompilerDirectives.transferToInterpreterAndInvalidate();
+                    throw EspressoError.shouldNotReachHere("expecting IF_ACMPEQ,IF_ACMPNE");
+            }
+        } else {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            Meta meta = getMeta();
+            if (operand1 != operand2) {
+                if (meta.java_lang_Integer.equals(operand1.getKlass()) &&
+                        meta.java_lang_Integer.equals(operand2.getKlass())) {
 
-        if (analyze) {
+                    int int1 = meta.java_lang_Integer_value.getInt(operand1);
+                    int int2 = meta.java_lang_Integer_value.getInt(operand2);
+
+                    if (int1 == int2 && int1 >= -128 && int1 <= 127) {
+                        result = (opcode == IF_ACMPEQ);
+                    } else {
+                        result = (opcode != IF_ACMPEQ);
+                    }
+                } else {
+                    result = (opcode != IF_ACMPEQ);
+                }
+            } else {
+                result = (opcode == IF_ACMPEQ);
+            }
             analysis.takeBranchRef2(frame, bcn, bci, opcode, result, operand1, operand2,
                     Annotations.objectAnnotation(operand1), Annotations.objectAnnotation(operand2));
         }
-
+        // @formatter:on
         return result;
     }
 
@@ -2007,13 +2026,42 @@ public class SPouT {
         return meta.toGuestString(ret);
     }
 
-    public static StaticObject valueOf_int(Object v, Meta meta) {
+    public static StaticObject string_valueOf_int(Object v, Meta meta) {
         if (v instanceof AnnotatedValue && config.hasConcolicAnalysis() && Annotations.annotation((Annotations) v, config.getConcolicIdx()) != null) {
             stopRecording("concolic type conversion from int to string not supported, yet.", meta);
         }
 
         String ret = "" + (int) AnnotatedValue.value(v);
         return meta.toGuestString(ret);
+    }
+
+    private static StaticObject[] intCache;
+    private static void initIntCache() {
+        Meta meta = getMeta();
+        intCache = new StaticObject[256];
+        for (int i=-128; i <= 127; i++) {
+            StaticObject o = meta.java_lang_Integer.allocateInstance();
+            meta.java_lang_Integer_value.set(o, AnnotatedValue.value(i));
+            intCache[128 + i] = o;
+        }
+    }
+
+    @CompilerDirectives.TruffleBoundary
+    public static StaticObject integer_valueOf_int(Object i, Meta meta) {
+        StaticObject o;
+        int v =  AnnotatedValue.value(i);
+        if (analyze || v < -128 || 127 < v)  {
+            o = meta.java_lang_Integer.allocateInstance();
+            meta.java_lang_Integer_value.set(o, AnnotatedValue.value(i));
+            AnnotatedVM.setFieldAnnotation(o, meta.java_lang_Integer_value,
+                    AnnotatedValue.svalue(i));
+        } else {
+            if (intCache == null) {
+                initIntCache();
+            }
+            o = intCache[128 - v];
+        }
+        return o;
     }
 
     public static StaticObject valueOf_long(Object v, Meta meta) {

--- a/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/spout/SPouT.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/spout/SPouT.java
@@ -179,7 +179,7 @@ public class SPouT {
 
     @CompilerDirectives.TruffleBoundary
     public static Object nextSymbolicLong() {
-        if (!analyze || !config.hasConcolicAnalysis()) return 0;
+        if (!analyze || !config.hasConcolicAnalysis()) return 0l;
         Object av = config.getConcolicAnalysis().nextSymbolicLong();
         gwit.trackLocationForWitness("" + (long) ((AnnotatedValue) av).getValue() + "L");
         return av;
@@ -187,7 +187,7 @@ public class SPouT {
 
     @CompilerDirectives.TruffleBoundary
     public static Object nextSymbolicFloat() {
-        if (!analyze || !config.hasConcolicAnalysis()) return 0;
+        if (!analyze || !config.hasConcolicAnalysis()) return 0f;
         Object av = config.getConcolicAnalysis().nextSymbolicFloat();
         gwit.trackLocationForWitness("Float.parseFloat(\"" +
                 (float) ((AnnotatedValue) av).getValue() + "\")");
@@ -196,7 +196,7 @@ public class SPouT {
 
     @CompilerDirectives.TruffleBoundary
     public static Object nextSymbolicDouble() {
-        if (!analyze || !config.hasConcolicAnalysis()) return 0;
+        if (!analyze || !config.hasConcolicAnalysis()) return 0d;
         Object av = config.getConcolicAnalysis().nextSymbolicDouble();
         gwit.trackLocationForWitness("Double.parseDouble(\"" +
                 (double) ((AnnotatedValue) av).getValue() + "\")");
@@ -1273,6 +1273,42 @@ public class SPouT {
     public static Object mathCos(Object a, Meta meta) {
         if(AnnotatedValue.svalue(a) != null) stopRecording("Math.cos is not symbolically implemented yet", meta);
         return Math.cos((double) a);
+    }
+
+    public static Object mathAbsInt(Object a){
+        int cRes = Math.abs(AnnotatedValue.value(a));
+        if(AnnotatedValue.svalue(a) != null){
+            return new AnnotatedValue(cRes, analysis.mathAbs(AnnotatedValue.value(a), AnnotatedValue.svalue(a)));
+        }else{
+            return cRes;
+        }
+    }
+
+    public static Object mathAbsLong(Object a){
+        long cRes = Math.abs((long)AnnotatedValue.value(a));
+        if(AnnotatedValue.svalue(a) != null){
+            return new AnnotatedValue(cRes, analysis.mathAbs((long) AnnotatedValue.value(a), AnnotatedValue.svalue(a)));
+        }else{
+            return cRes;
+        }
+    }
+    public static Object mathAbsFloat(Object a){
+        float cRes = Math.abs((float)AnnotatedValue.value(a));
+        if(AnnotatedValue.svalue(a) != null){
+            return new AnnotatedValue(cRes,analysis.mathAbs((float) AnnotatedValue.value(a), AnnotatedValue.svalue(a)));
+        }else{
+            return cRes;
+        }
+    }
+    public static Object mathAbsDouble(Object a){
+        SPouT.debug("MathAbsDouble1", a.getClass());
+        double cRes = Math.abs((double)AnnotatedValue.value(a));
+        if(AnnotatedValue.svalue(a) != null){
+            return new AnnotatedValue(cRes, analysis.mathAbs((double) AnnotatedValue.value(a), AnnotatedValue.svalue(a)));
+        }else{
+            SPouT.debug("MathAbsDouble", cRes);
+            return cRes;
+        }
     }
 
 //    @CompilerDirectives.TruffleBoundary

--- a/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/spout/SPouT.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/spout/SPouT.java
@@ -2059,7 +2059,7 @@ public class SPouT {
             if (intCache == null) {
                 initIntCache();
             }
-            o = intCache[128 - v];
+            o = intCache[128 + v];
         }
         return o;
     }

--- a/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/spout/SPouT.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/spout/SPouT.java
@@ -611,7 +611,7 @@ public class SPouT {
 
     private static void checkNotZero(VirtualFrame frame, long c1, Annotations a, BytecodeNode bcn, int bci) {
         if (analyze) {
-            analysis.checkNotZeroInt(frame, bcn, bci, c1 == 0L, a);
+            analysis.checkNotZeroLong(frame, bcn, bci, c1 == 0L, a);
         }
         if (c1 == 0L) {
             bcn.enterImplicitExceptionProfile();
@@ -1877,6 +1877,34 @@ public class SPouT {
             if(a != null) return new AnnotatedValue(res, a);
         }
         return res;
+    }
+
+    public static Object characterIsAlphabetic(Object codePoint, Meta meta) {
+        if(AnnotatedValue.svalue(codePoint) != null) stopRecording("Character.isAlphabetic is not symbolically implemented yet", meta);
+        return Character.isAlphabetic((AnnotatedValue.value(codePoint)));
+    }
+
+    public static Object characterIsJavaIdentifierStart(Object codePoint, Meta meta) {
+        if(AnnotatedValue.svalue(codePoint) != null) stopRecording("Character.isJavaIdentifierStart is not symbolically implemented yet", meta);
+        return Character.isJavaIdentifierStart((AnnotatedValue.value(codePoint)));
+    }
+    public static Object characterIsJavaIdentifierPart(Object codePoint, Meta meta) {
+        if(AnnotatedValue.svalue(codePoint) != null) stopRecording("Character.isJavaIdentifierPart is not symbolically implemented yet", meta);
+        return Character.isJavaIdentifierPart((AnnotatedValue.value(codePoint)));
+    }
+    public static Object characterIsUnicodeIdentifierPart(Object codePoint, Meta meta) {
+        if(AnnotatedValue.svalue(codePoint) != null) stopRecording("Character.isUnicodeIdentifiertPart is not symbolically implemented yet", meta);
+        return Character.isUnicodeIdentifierPart((AnnotatedValue.value(codePoint)));
+    }
+
+    public static Object characterIsUnicodeIdentifierStart(Object codePoint, Meta meta) {
+        if(AnnotatedValue.svalue(codePoint) != null) stopRecording("Character.isUnicodeIdentifiertStart is not symbolically implemented yet", meta);
+        return Character.isUnicodeIdentifierStart(AnnotatedValue.value(codePoint));
+    }
+
+    public static Object characterIsIdentiferIgnorable(Object codePoint, Meta meta) {
+        if(AnnotatedValue.svalue(codePoint) != null) stopRecording("Character.isIdentifierIgnorable is not symbolically implemented yet", meta);
+        return Character.isIdentifierIgnorable(AnnotatedValue.value(codePoint));
     }
 
     public static Object characterEquals(StaticObject self, StaticObject other, Meta meta) {

--- a/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/spout/SPouT.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/spout/SPouT.java
@@ -1860,7 +1860,7 @@ public class SPouT {
     public static Object characterToLowerCase(Object c, Meta meta) {
         char cChar = AnnotatedValue.value(c);
         Annotations sChar = AnnotatedValue.svalue(c);
-        char cRes = Character.toUpperCase(cChar);
+        char cRes = Character.toLowerCase(cChar);
         if(analyze){
             Annotations a = analysis.characterToLowerCase(cChar, sChar);
             if (a != null) return new AnnotatedValue(cRes, a);

--- a/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/taint/TaintAnalysis.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/taint/TaintAnalysis.java
@@ -621,6 +621,25 @@ public class TaintAnalysis implements Analysis<Taint> {
         return ColorUtil.joinColors(s, ifTaint);
     }
 
+    @Override
+    public Taint mathAbs(int c, Taint s) {
+        return  ColorUtil.joinColors(s, ifTaint);
+    }
+
+    @Override
+    public Taint mathAbs(long c, Taint s) {
+        return ColorUtil.joinColors(s, ifTaint);
+    }
+
+    @Override
+    public Taint mathAbs(float c, Taint s) {
+        return ColorUtil.joinColors(s, ifTaint);
+    }
+
+    @Override
+    public Taint mathAbs(double c, Taint s) {
+        return ColorUtil.joinColors(s, ifTaint);
+    }
 
     // Strings
 

--- a/scripts/graal-image.Dockerfile
+++ b/scripts/graal-image.Dockerfile
@@ -6,7 +6,8 @@ RUN wget https://github.com/graalvm/labs-openjdk-17/releases/download/jvmci-22.3
     tar -xzf labsjdk-ce-17.0.5+5-jvmci-22.3-b06-linux-amd64.tar.gz
 ENV JAVA_HOME=/data/labsjdk-ce-17.0.5-jvmci-22.3-b06/
 
-RUN git clone https://github.com/graalvm/mx.git
+RUN git clone https://github.com/graalvm/mx.git && \
+    git checkout b62c4ec0
 ENV PATH=/data/mx:$JAVA_HOME/bin:$PATH
 RUN echo $PATH
 RUN java -version && javac -version

--- a/scripts/graal-image.Dockerfile
+++ b/scripts/graal-image.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ubuntu:24.04
+FROM --platform=linux/amd64 ubuntu:20.04
 WORKDIR /data
 RUN apt-get update && apt-get install -y wget git python3 python-is-python3
 

--- a/scripts/graal-image.Dockerfile
+++ b/scripts/graal-image.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ubuntu:20.04
+FROM --platform=linux/amd64 ubuntu:24.04
 WORKDIR /data
 RUN apt-get update && apt-get install -y wget git python3 python-is-python3
 

--- a/scripts/graal-image.Dockerfile
+++ b/scripts/graal-image.Dockerfile
@@ -16,6 +16,6 @@ RUN wget https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.2.
 ENV PATH=/data/graalvm-ce-java17-22.2.0/bin:$PATH
 RUN gu install native-image
 RUN DEBIAN_FRONTEND="noninteractive" apt-get -y install build-essential libz-dev zlib1g-dev pip cmake gcc g++
-RUN wget https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.tar.gz && \
-    tar -xzf apache-maven-3.8.6-bin.tar.gz
-ENV PATH=/data/apache-maven-3.8.6/bin:$PATH
+RUN wget https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz && \
+    tar -xzf apache-maven-3.9.11-bin.tar.gz
+ENV PATH=/data/apache-maven-3.9.11/bin:$PATH

--- a/scripts/graal-image.Dockerfile
+++ b/scripts/graal-image.Dockerfile
@@ -7,7 +7,7 @@ RUN wget https://github.com/graalvm/labs-openjdk-17/releases/download/jvmci-22.3
 ENV JAVA_HOME=/data/labsjdk-ce-17.0.5-jvmci-22.3-b06/
 
 RUN git clone https://github.com/graalvm/mx.git && \
-    git checkout b62c4ec0
+    cd mx; git checkout b62c4ec0; cd ..;
 ENV PATH=/data/mx:$JAVA_HOME/bin:$PATH
 RUN echo $PATH
 RUN java -version && javac -version


### PR DESCRIPTION
IntegerCache leads to unintended concretization

Addresses the issue reported in [https://github.com/tudo-aqua/gdart/issues/5](https://github.com/tudo-aqua/gdart/issues/5)

This PR implements the symbolic semantics described in the JLS for an IntegerCache of size 256.