### PR TITLE
Use SMT-LIB compliant operator.

### DIFF
--- a/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/smt/OperatorComparator.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/smt/OperatorComparator.java
@@ -253,7 +253,7 @@ public enum OperatorComparator {
                 return "=";
             case BVNE:
             case STRINGNE:
-                return "!=";
+                return "distinct";
             case BVGT:
                 return "bvsgt";
             case BVGE:


### PR DESCRIPTION
Hi,

I've noticed that serializing the path conditions into SMT-LIB notation had a typo for the distinct operator. This PR fixes it.

Best,
Manuel