### PR TITLE
Fix path conditions for array accesses.

### DIFF
--- a/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/concolic/ConcolicAnalysis.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/concolic/ConcolicAnalysis.java
@@ -596,6 +596,9 @@ public class ConcolicAnalysis implements Analysis<Expression> {
                     new ComplexExpression(BVLE, INT_ZERO, sIndex),
                     new ComplexExpression(BVLT, sIndex, sLen));
 
+            // The path conditions must characterize the path taken by the execution.
+            arrayBound = new ComplexExpression(BAND, arrayBound, new ComplexExpression(BVEQ, sIndex, Constant.fromConcreteValue(cIndex)));
+
             trace.addElement(new PathCondition(
                     safe ? arrayBound : new ComplexExpression(BNEG, arrayBound), safe ? FAILURE : SUCCESS, BINARY_SPLIT));
         }


### PR DESCRIPTION
Hi,

This is a follow-up regarding issue #5. 

The issue reported that symbolic array accesses can lead to unsound path conditions, which means that two inputs satisfying the same path conditions can follow different paths in the code.  

This PR aims to resolve this, ensuring that inputs satisfying the same path conditions follow the same path in the code. This is the simplest solution I have found.

Best,
Manuel