### PR TITLE
Fix typo in division handling

### DIFF
--- a/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/spout/SPouT.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/spout/SPouT.java
@@ -611,7 +611,7 @@ public class SPouT {
 
     private static void checkNotZero(VirtualFrame frame, long c1, Annotations a, BytecodeNode bcn, int bci) {
         if (analyze) {
-            analysis.checkNotZeroInt(frame, bcn, bci, c1 == 0L, a);
+            analysis.checkNotZeroLong(frame, bcn, bci, c1 == 0L, a);
         }
         if (c1 == 0L) {
             bcn.enterImplicitExceptionProfile();


### PR DESCRIPTION
Hi,

I noticed a typo in the division handling that yields invalid SMT-LIB constraints. This PR fixes it.