### PR TITLE
Fix SMT-LIB serialization for INEG and LNEG.

### DIFF
--- a/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/smt/OperatorComparator.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/tools/aqua/smt/OperatorComparator.java
@@ -207,7 +207,7 @@ public enum OperatorComparator {
                 return "bvxor";
             case INEG:
             case LNEG:
-                return "-";
+                return "bvneg";
 
             // float and double
             case FADD:


### PR DESCRIPTION
The "-" operator is not defined for bitvectors in SMT-LIB.